### PR TITLE
Configure Vitest and add component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest",
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
@@ -29,6 +30,9 @@
     "eslint-plugin-react-refresh": "^0.4.16",
     "gh-pages": "^6.3.0",
     "globals": "^15.14.0",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.2"
   }
 }

--- a/src/components/__tests__/JokerCard.test.jsx
+++ b/src/components/__tests__/JokerCard.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import JokerCard from '../JokerCard.jsx';
+
+const sampleJoker = {
+  number: '1',
+  name: 'Joker',
+  effect: '+4 Mult',
+  cost: '$2',
+  rarity: 'Common'
+};
+
+describe('JokerCard', () => {
+  test('renders joker information and link', () => {
+    render(
+      <MemoryRouter>
+        <JokerCard joker={sampleJoker} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByAltText('Joker')).toBeInTheDocument();
+    expect(screen.getByText('Joker')).toBeInTheDocument();
+    expect(screen.getByText('+4 Mult')).toBeInTheDocument();
+
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('href')).toBe('/joker/joker');
+  });
+});

--- a/src/pages/__tests__/JokerPage.test.jsx
+++ b/src/pages/__tests__/JokerPage.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import JokerPage from '../JokerPage.jsx';
+
+function renderWithRouter(path) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/joker/:name" element={<JokerPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('JokerPage', () => {
+  test('shows joker details when joker exists', () => {
+    renderWithRouter('/joker/joker');
+
+    expect(screen.getByRole('heading', { name: 'Joker' })).toBeInTheDocument();
+    expect(screen.getByText('+4 Mult')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /back to grid/i })).toHaveAttribute(
+      'href',
+      '/'
+    );
+  });
+
+  test('displays not found for unknown joker', () => {
+    renderWithRouter('/joker/unknown-joker');
+    expect(screen.getByText(/joker not found/i)).toBeInTheDocument();
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,9 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/balatro/'
+  base: '/balatro/',
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.js'
+  }
 })


### PR DESCRIPTION
## Summary
- configure Vitest with jsdom and a setup file
- add a test script and testing deps
- create tests for `JokerCard` and `JokerPage` components

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855658476948326bb82fd0be9adb0d8