### PR TITLE
Replace inline Joker styles with CSS classes

### DIFF
--- a/src/components/JokerCard.jsx
+++ b/src/components/JokerCard.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Tooltip } from 'react-tooltip';
+import './jokerStyles.css';
 
 const images = import.meta.glob('../assets/images/*.png', { eager: true });
 
@@ -12,51 +13,18 @@ function JokerCard({ joker }) {
   const imageUrl = images[imageKey]?.default;
   
   return (
-    <div style={{
-      position: 'relative',
-      width: '180px',
-      height: '180px',
-      margin: '0 auto',
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center'
-    }}>
+    <div className="joker-card">
       {/* Rest of your component remains the same */}
-      <div style={{
-        position: 'absolute',
-        top: '10px',
-        width: '160px',
-        height: '160px',
-        backgroundColor: '#1f1f1f',
-        borderRadius: '12px',
-        boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
-        transition: 'all 0.3s ease',
-        border: '2px solid #2a1f1f',
-        zIndex: 1
-      }}/>
-      <Link 
+      <div className="joker-card-bg" />
+      <Link
         to={`/joker/${joker.name.toLowerCase().replace(/\s+/g, '-')}`}
         data-tooltip-id={`tooltip-${joker.number}`}
-        style={{
-          position: 'relative',
-          zIndex: 2,
-          display: 'block',
-          textDecoration: 'none',
-          transition: 'transform 0.3s ease',
-          ':hover': {
-            transform: 'translateY(-5px)'
-          }
-        }}
+        className="joker-card-link"
       >
-        <img 
+        <img
           src={imageUrl}
           alt={joker.name}
-          style={{ 
-            width: '180px', 
-            height: '180px', 
-            objectFit: 'contain',
-            filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.2))'
-          }}
+          className="joker-image"
         />
       </Link>
       

--- a/src/components/JokerTable.jsx
+++ b/src/components/JokerTable.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import './jokerStyles.css';
 
 function JokerTable({ jokers }) {
   const [filters, setFilters] = useState({
@@ -33,7 +34,7 @@ function JokerTable({ jokers }) {
     <select
       value={filters[column]}
       onChange={(e) => setFilters({ ...filters, [column]: e.target.value })}
-      style={filterSelectStyle}
+      className="joker-select"
     >
       <option value="">All</option>
       {getUniqueValues(column).map(value => (
@@ -43,67 +44,35 @@ function JokerTable({ jokers }) {
   );
 
   return (
-    <div style={{
-      padding: '1rem',
-      maxWidth: '1200px',
-      margin: '0 auto',
-      backgroundColor: '#1a1a1a',
-      borderRadius: '12px',
-      boxShadow: '0 4px 6px rgba(0, 0, 0, 0.2)'
-    }}>
-      <div style={{ 
-        marginBottom: '1rem', 
-        textAlign: 'right',
-        padding: '0 1rem'
-      }}>
+    <div className="joker-table-container">
+      <div className="joker-table-header">
         <button
           onClick={resetFilters}
-          style={{
-            padding: '0.8rem 1.5rem',
-            borderRadius: '8px',
-            border: '2px solid #c41e3a',
-            backgroundColor: '#2a1f1f',
-            color: '#fff',
-            cursor: 'pointer',
-            fontSize: '0.9rem',
-            fontFamily: 'Playfair Display, serif',
-            transition: 'all 0.3s ease',
-            boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
-            ':hover': {
-              backgroundColor: '#c41e3a',
-              transform: 'translateY(-2px)'
-            }
-          }}
+          className="reset-filters-btn"
         >
           Reset Filters
         </button>
       </div>
-      <div style={{ overflowX: 'auto' }}>
-        <table style={{ 
-          width: '100%', 
-          borderCollapse: 'collapse',
-          backgroundColor: '#1f1f1f',
-          borderRadius: '8px',
-          overflow: 'hidden'
-        }}>
+      <div className="joker-table-wrapper">
+        <table className="joker-table">
           <thead>
             <tr>
-              <th style={tableHeaderStyle}>Number</th>
-              <th style={tableHeaderStyle}>Name</th>
-              <th style={tableHeaderStyle}>Effect</th>
-              <th style={tableHeaderStyle}>
+              <th className="joker-th">Number</th>
+              <th className="joker-th">Name</th>
+              <th className="joker-th">Effect</th>
+              <th className="joker-th">
                 Cost
                 <div><FilterDropdown column="cost" /></div>
               </th>
-              <th style={tableHeaderStyle}>
+              <th className="joker-th">
                 Rarity
                 <div><FilterDropdown column="rarity" /></div>
               </th>
-              <th style={tableHeaderStyle}>
+              <th className="joker-th">
                 Type
                 <div><FilterDropdown column="type" /></div>
               </th>
-              <th style={tableHeaderStyle}>
+              <th className="joker-th">
                 Activation
                 <div><FilterDropdown column="activation" /></div>
               </th>
@@ -111,34 +80,28 @@ function JokerTable({ jokers }) {
           </thead>
           <tbody>
             {filteredJokers.map((joker) => (
-              <tr key={joker.number} style={{
-                ...tableRowStyle,
-                backgroundColor: filteredJokers.indexOf(joker) % 2 === 0 ? '#1a1a1a' : '#1f1f1f'
-              }}>
-                <td style={tableCellStyle}>{joker.number}</td>
-                <td style={tableCellStyle}>
+              <tr
+                key={joker.number}
+                className="joker-row"
+                style={{
+                  backgroundColor:
+                    filteredJokers.indexOf(joker) % 2 === 0 ? '#1a1a1a' : '#1f1f1f'
+                }}
+              >
+                <td className="joker-td">{joker.number}</td>
+                <td className="joker-td">
                   <Link
                     to={`/joker/${joker.name.toLowerCase().replace(/\s+/g, '-')}`}
-                    style={{
-                      color: '#c41e3a',
-                      textDecoration: 'none',
-                      transition: 'all 0.3s ease',
-                      fontFamily: 'Playfair Display, serif',
-                      display: 'block',
-                      ':hover': {
-                        color: '#ff2e4a',
-                        textDecoration: 'underline'
-                      }
-                    }}
+                    className="joker-link"
                   >
                     {joker.name}
                   </Link>
                 </td>
-                <td style={tableCellStyle}>{joker.effect}</td>
-                <td style={tableCellStyle}>{joker.cost}</td>
-                <td style={tableCellStyle}>{joker.rarity}</td>
-                <td style={tableCellStyle}>{joker.type}</td>
-                <td style={tableCellStyle}>{joker.activation}</td>
+                <td className="joker-td">{joker.effect}</td>
+                <td className="joker-td">{joker.cost}</td>
+                <td className="joker-td">{joker.rarity}</td>
+                <td className="joker-td">{joker.type}</td>
+                <td className="joker-td">{joker.activation}</td>
               </tr>
             ))}
           </tbody>
@@ -147,46 +110,5 @@ function JokerTable({ jokers }) {
     </div>
   );
 }
-
-const tableHeaderStyle = {
-  padding: '16px',
-  textAlign: 'left',
-  borderBottom: '2px solid #c41e3a',
-  backgroundColor: '#2a1f1f',
-  color: '#fff',
-  fontFamily: 'Playfair Display, serif',
-  fontSize: '1.1rem'
-};
-
-const tableCellStyle = {
-  padding: '12px',
-  borderBottom: '1px solid #3a3a3a',
-  color: '#fff',
-  fontFamily: 'Playfair Display, serif'
-};
-
-const tableRowStyle = {
-  transition: 'background-color 0.3s ease',
-  ':hover': {
-    backgroundColor: '#2a1f1f'
-  }
-};
-
-const filterSelectStyle = {
-  backgroundColor: '#2a1f1f',
-  color: '#fff',
-  border: '1px solid #c41e3a',
-  borderRadius: '4px',
-  padding: '6px',
-  marginTop: '6px',
-  width: '100%',
-  fontSize: '0.9rem',
-  fontFamily: 'Playfair Display, serif',
-  cursor: 'pointer',
-  transition: 'all 0.3s ease',
-  ':hover': {
-    borderColor: '#ff2e4a'
-  }
-};
 
 export default JokerTable;

--- a/src/components/jokerStyles.css
+++ b/src/components/jokerStyles.css
@@ -1,0 +1,142 @@
+.joker-card {
+  position: relative;
+  width: 180px;
+  height: 180px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.joker-card-bg {
+  position: absolute;
+  top: 10px;
+  width: 160px;
+  height: 160px;
+  background-color: #1f1f1f;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  transition: all 0.3s ease;
+  border: 2px solid #2a1f1f;
+  z-index: 1;
+}
+
+.joker-card-link {
+  position: relative;
+  z-index: 2;
+  display: block;
+  text-decoration: none;
+  transition: transform 0.3s ease;
+}
+
+.joker-card-link:hover {
+  transform: translateY(-5px);
+}
+
+.joker-image {
+  width: 180px;
+  height: 180px;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
+}
+
+.joker-table-container {
+  padding: 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  background-color: #1a1a1a;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.joker-table-header {
+  margin-bottom: 1rem;
+  text-align: right;
+  padding: 0 1rem;
+}
+
+.reset-filters-btn {
+  padding: 0.8rem 1.5rem;
+  border-radius: 8px;
+  border: 2px solid #c41e3a;
+  background-color: #2a1f1f;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-family: 'Playfair Display, serif';
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.reset-filters-btn:hover {
+  background-color: #c41e3a;
+  transform: translateY(-2px);
+}
+
+.joker-table-wrapper {
+  overflow-x: auto;
+}
+
+.joker-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #1f1f1f;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.joker-th {
+  padding: 16px;
+  text-align: left;
+  border-bottom: 2px solid #c41e3a;
+  background-color: #2a1f1f;
+  color: #fff;
+  font-family: 'Playfair Display, serif';
+  font-size: 1.1rem;
+}
+
+.joker-td {
+  padding: 12px;
+  border-bottom: 1px solid #3a3a3a;
+  color: #fff;
+  font-family: 'Playfair Display, serif';
+}
+
+.joker-row {
+  transition: background-color 0.3s ease;
+}
+
+.joker-row:hover {
+  background-color: #2a1f1f;
+}
+
+.joker-link {
+  color: #c41e3a;
+  text-decoration: none;
+  transition: all 0.3s ease;
+  font-family: 'Playfair Display, serif';
+  display: block;
+}
+
+.joker-link:hover {
+  color: #ff2e4a;
+  text-decoration: underline;
+}
+
+.joker-select {
+  background-color: #2a1f1f;
+  color: #fff;
+  border: 1px solid #c41e3a;
+  border-radius: 4px;
+  padding: 6px;
+  margin-top: 6px;
+  width: 100%;
+  font-size: 0.9rem;
+  font-family: 'Playfair Display, serif';
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.joker-select:hover {
+  border-color: #ff2e4a;
+}


### PR DESCRIPTION
## Summary
- create shared `jokerStyles.css`
- import new stylesheet in `JokerCard` and `JokerTable`
- apply class-based styling for cards, table rows and links

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6855655e37888326817013502950e8cf