### PR TITLE
Update MIT license and README disclaimer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ryan Adamczyk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
-# React + Vite
+# Balatro Joker Guide
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A small web reference for every **Joker** card in the roguelike deckbuilder **Balatro**. Browse all cards in a grid or table view and open any Joker for details on its cost, effect, rarity and unlock requirements.
 
 ## Disclaimer
 
 This project is a personal experiment. I do **not** have any rights to the art from the game **Balatro**. Any images or assets from the original game remain the property of their respective owners and appear here solely for non-commercial, educational purposes.
 
-Currently, two official plugins are available:
+## Local development
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+1. Install dependencies with:
+   ```bash
+   npm install
+   ```
+2. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+   The site will be available at the URL shown in your terminal.
+
+## Deployed site
+
+See it live at [radamczyk.com/balatro](https://radamczyk.com/balatro/).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Disclaimer
+
+This project is a personal experiment. I do **not** have any rights to the art from the game **Balatro**. Any images or assets from the original game remain the property of their respective owners and appear here solely for non-commercial, educational purposes.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh


### PR DESCRIPTION
## Summary
- correct MIT license owner
- clarify that game art is not authorized

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855657055848326b5677cfdf3928b48