### PR TITLE
Fix joker image paths on main page

### DIFF
--- a/src/components/JokerCard.jsx
+++ b/src/components/JokerCard.jsx
@@ -5,10 +5,9 @@ import './jokerStyles.css';
 const images = import.meta.glob('../assets/images/*.png', { eager: true });
 
 function JokerCard({ joker }) {
-  // Convert joker name to match image filename format (capitalize first letters)
-  const imageName = joker.name.split(' ')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('_');
+  // Convert joker name to match image filename format by replacing spaces
+  // with underscores while preserving the original casing and punctuation.
+  const imageName = joker.name.split(' ').join('_');
   const imageKey = `../assets/images/${imageName}.png`;
   const imageUrl = images[imageKey]?.default;
   


### PR DESCRIPTION
## Summary
- update image name logic so `the` and other words match actual file names

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556c39515c832682bd6e8de7a2e014